### PR TITLE
Fix Ghost Frog rng instanciation

### DIFF
--- a/TinyLink/Source/Actors/GhostFrog.cs
+++ b/TinyLink/Source/Actors/GhostFrog.cs
@@ -39,7 +39,7 @@ public class GhostFrog : Actor
 		Depth = -5;
 		Hitbox = new(new RectInt(-4, -12, 8, 12));
 		Mask = Masks.Enemy;
-		rng = new((int)Time.Elapsed.Ticks);
+		rng = new(Guid.NewGuid().Variant);
 		Play("sword");
 
 		stateRoutines = new[]


### PR DESCRIPTION
close FosterFramework/Samples#5

Rng was taking Time to create a random seed but Time is null during the constructor and is available only right after the constructor.
Fixed it using a Guid instead.